### PR TITLE
Format Money Values with Trailing 0 Characters

### DIFF
--- a/Sources/PayPal/Models/Money/Amount.swift
+++ b/Sources/PayPal/Models/Money/Amount.swift
@@ -120,6 +120,6 @@ public struct AmountType<Key>: Content, Amount, Equatable where Key: AmountCodin
         }
         
         try container.encode(self.currency, forKey: .currency)
-        try container.encode(String(describing: rounded), forKey: .value)
+        try container.encode(self.currency.string(for: self.value), forKey: .value)
     }
 }

--- a/Sources/PayPal/Models/Money/Currency.swift
+++ b/Sources/PayPal/Models/Money/Currency.swift
@@ -95,9 +95,14 @@ public struct Currency: Content, Equatable {
         
         if -rounded.exponent != self.e {
             var string = rounded.description
+            let oCount: Int
             
-            let index = string.index(string.firstIndex(of: ".") ?? string.endIndex, offsetBy: 1, limitedBy: string.endIndex) ?? string.endIndex
-            let oCount = (self.e ?? 0) - string[index...].count
+            if let i = string.firstIndex(of: ".") {
+                oCount = string[string.index(after: i)...].count
+            } else {
+                oCount = self.e ?? 0
+                string.append(".")
+            }
             
             string.append(String(repeating: "0", count: oCount))
             return string

--- a/Sources/PayPal/Models/Money/DetailedAmount.swift
+++ b/Sources/PayPal/Models/Money/DetailedAmount.swift
@@ -41,8 +41,8 @@ public struct DetailedAmount: Content, Equatable {
     /// See [`Encodable.encode(to:)`](https://developer.apple.com/documentation/swift/encodable/2893603-encode).
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(String(describing: self.amount.value), forKey: .total)
         try container.encode(self.amount.currency, forKey: .currency)
+        try container.encode(self.amount.currency.string(for: self.amount.value), forKey: .total)
         try container.encodeIfPresent(self.details, forKey: .details)
     }
     

--- a/Tests/ModelTests/AcceptDisputeTests.swift
+++ b/Tests/ModelTests/AcceptDisputeTests.swift
@@ -53,7 +53,7 @@ final class AcceptDisputeTests: XCTestCase {
         let generated = try String(data: encoder.encode(body), encoding: .utf8)!
         let json =
             "{\"accept_claim_reason\":\"COMPANY_POLICY\",\"invoice_id\":\"3EC9D031-0DBF-446F-ABC0-31B4A6E0D2B5\"," +
-            "\"note\":\"Refund to customer\",\"refund_amount\":{\"value\":\"55.5\",\"currency_code\":\"USD\"}}"
+            "\"note\":\"Refund to customer\",\"refund_amount\":{\"value\":\"55.50\",\"currency_code\":\"USD\"}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/BillingPlanListTests.swift
+++ b/Tests/ModelTests/BillingPlanListTests.swift
@@ -67,9 +67,9 @@ final class BillingPlanListTests: XCTestCase {
             ])
         let generated = try String(data: encoder.encode(list), encoding: .utf8)!
         let json =
-            "{\"plans\":[{\"payment_definitions\":[{\"frequency\":\"MONTH\",\"amount\":{\"currency\":\"USD\",\"value\":\"10\"},\"frequency_interval\":\"1\"," +
-            "\"cycles\":\"0\",\"name\":\"Water Charge\",\"type\":\"REGULAR\"}],\"name\":\"Monthly Water\",\"type\":\"INFINITE\"," +
-            "\"description\":\"Your water payment\"}],\"total_items\":\"1\"}"
+            "{\"plans\":[{\"payment_definitions\":[{\"frequency\":\"MONTH\",\"amount\":{\"currency\":\"USD\",\"value\":\"10.00\"}," +
+            "\"frequency_interval\":\"1\",\"cycles\":\"0\",\"name\":\"Water Charge\",\"type\":\"REGULAR\"}],\"name\":\"Monthly Water\"," +
+            "\"type\":\"INFINITE\",\"description\":\"Your water payment\"}],\"total_items\":\"1\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/BillingPlanTests.swift
+++ b/Tests/ModelTests/BillingPlanTests.swift
@@ -95,7 +95,7 @@ final class BillingPlanTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(plan), encoding: .utf8)!
         let json =
-            "{\"payment_definitions\":[{\"frequency\":\"MONTH\",\"amount\":{\"currency\":\"USD\",\"value\":\"10\"},\"frequency_interval\":\"1\"," +
+            "{\"payment_definitions\":[{\"frequency\":\"MONTH\",\"amount\":{\"currency\":\"USD\",\"value\":\"10.00\"},\"frequency_interval\":\"1\"," +
             "\"cycles\":\"0\",\"name\":\"Water Charge\",\"type\":\"REGULAR\"}],\"name\":\"Monthly Water\",\"type\":\"INFINITE\"," +
             "\"description\":\"Your water payment\"}"
         

--- a/Tests/ModelTests/CaptureTests.swift
+++ b/Tests/ModelTests/CaptureTests.swift
@@ -23,7 +23,7 @@ final class CaptureTests: XCTestCase {
             transaction: CurrencyAmount(currency: .usd, value: 1.00)
         )
         let generated = try String(data: encoder.encode(capture), encoding: .utf8)
-        let json = "{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"},\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"1\"}}"
+        let json = "{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"},\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"1.00\"}}"
         
         XCTAssertEqual(generated, json)
     }

--- a/Tests/ModelTests/DetailTests.swift
+++ b/Tests/ModelTests/DetailTests.swift
@@ -48,7 +48,7 @@ final class DetailTests: XCTestCase {
         let json =
             "{\"final_payment_date\":\"\(later)\",\"last_payment_date\":\"\(now)\",\"failed_payment_count\":\"5\"," +
             "\"cycles_remaining\":\"30\",\"cycles_completed\":\"45\",\"last_payment_amount\":{\"value\":\"19.97\",\"currency_code\":\"USD\"}," +
-            "\"outstanding_balance\":{\"value\":\"599\",\"currency_code\":\"USD\"},\"next_billing_date\":\"\(oneYear)\"}"
+            "\"outstanding_balance\":{\"value\":\"599.00\",\"currency_code\":\"USD\"},\"next_billing_date\":\"\(oneYear)\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/DetailedAmountTests.swift
+++ b/Tests/ModelTests/DetailedAmountTests.swift
@@ -24,7 +24,7 @@ final class DetailedAmountTests: XCTestCase {
         let encoder = JSONEncoder()
         let amount = DetailedAmount(currency: .usd, total: 172.89, details: .init(subtotal: 134.56))
         let generated = try String(data: encoder.encode(amount), encoding: .utf8)
-        let json = "{\"total\":\"172.89\",\"currency\":\"USD\",\"details\":{\"subtotal\":\"134.56\"}}"
+        let json = "{\"currency\":\"USD\",\"total\":\"172.89\",\"details\":{\"subtotal\":\"134.56\"}}"
         
         XCTAssertEqual(generated, json)
     }

--- a/Tests/ModelTests/DisputeResolutionOffer.swift
+++ b/Tests/ModelTests/DisputeResolutionOffer.swift
@@ -59,7 +59,8 @@ final class DisputeResolutionOfferTests: XCTestCase {
             invoiceID: nil
         )
         let generated = try String(data: encoder.encode(offer), encoding: .utf8)!
-        let json = "{\"offer_type\":\"REFUND_WITH_REPLACEMENT\",\"offer_amount\":{\"value\":\"23\",\"currency_code\":\"USD\"},\"note\":\"Notable note.\"}"
+        let json =
+            "{\"offer_type\":\"REFUND_WITH_REPLACEMENT\",\"offer_amount\":{\"value\":\"23.00\",\"currency_code\":\"USD\"},\"note\":\"Notable note.\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/InvoiceItemTests.swift
+++ b/Tests/ModelTests/InvoiceItemTests.swift
@@ -109,7 +109,7 @@ final class InvoiceItemTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(item), encoding: .utf8)!
         let json =
-            "{\"quantity\":3,\"unit_price\":{\"currency\":\"USD\",\"value\":\"50\"},\"unit_of_measure\":\"QUANTITY\",\"name\":\"Widget\"," +
+            "{\"quantity\":3,\"unit_price\":{\"currency\":\"USD\",\"value\":\"50.00\"},\"unit_of_measure\":\"QUANTITY\",\"name\":\"Widget\"," +
             "\"description\":\"Round and white, like a ping-pong ball\",\"date\":\"\(self.now.iso8601)\"}"
         
         var index = 0

--- a/Tests/ModelTests/InvoicePaymentTests.swift
+++ b/Tests/ModelTests/InvoicePaymentTests.swift
@@ -17,7 +17,9 @@ final class InvoicePaymentTests: XCTestCase {
         let encoder = JSONEncoder()
         let payment = Invoice.Payment(method: .cash, amount: CurrencyAmount(currency: .usd, value: 20.00), date: self.now, note: "I got the payment by cash!")
         let generated = try String(data: encoder.encode(payment), encoding: .utf8)!
-        let json = "{\"amount\":{\"currency\":\"USD\",\"value\":\"20\"},\"method\":\"CASH\",\"note\":\"I got the payment by cash!\",\"date\":\"\(self.now.iso8601)\"}"
+        let json =
+            "{\"amount\":{\"currency\":\"USD\",\"value\":\"20.00\"},\"method\":\"CASH\",\"note\":\"I got the payment by cash!\"," +
+            "\"date\":\"\(self.now.iso8601)\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/InvoiceTests.swift
+++ b/Tests/ModelTests/InvoiceTests.swift
@@ -192,10 +192,10 @@ final class InvoiceTests: XCTestCase {
             "{\"tax_calculated_after_discount\":true,\"invoice_date\":\"\(now.iso8601)\"," +
             "\"logo_url\":\"https:\\/\\/vapor.codes\\/dist\\/e032390c38279fbdf18ebf0e763eb44f.png\"," +
             "\"note\":\"Thanks for your donation!\",\"billing_info\":[],\"allow_partial_payment\":false,\"template_id\":\"PayPal system template\"," +
-            "\"minimum_amount_due\":{\"currency\":\"USD\",\"value\":\"1\"},\"merchant_info\":{\"email\":\"hello@vapor.codes\"" +
+            "\"minimum_amount_due\":{\"currency\":\"USD\",\"value\":\"1.00\"},\"merchant_info\":{\"email\":\"hello@vapor.codes\"" +
             ",\"last_name\":\"Nelson\",\"website\":\"https:\\/\\/vapor.codes\\/\",\"business_name\":\"Qutheory LLC.\",\"first_name\":\"Tanner\"}," +
             "\"cc_info\":[{\"email\":\"collective@vapor.codes\"},{\"email\":\"donator@example.com\"}],\"payment_term\":{" +
-            "\"due_date\":\"\(self.dueStr)\",\"term_type\":\"DUE_ON_RECEIPT\"},\"custom\":{\"amount\":{\"currency\":\"USD\",\"value\":\"10\"}}," +
+            "\"due_date\":\"\(self.dueStr)\",\"term_type\":\"DUE_ON_RECEIPT\"},\"custom\":{\"amount\":{\"currency\":\"USD\",\"value\":\"10.00\"}}," +
             "\"allow_tip\":true,\"reference\":\"PO number\",\"tax_inclusive\":true,\"merchant_memo\":\"Open Collective donation\"}"
         print(json.count)
         var index = 0

--- a/Tests/ModelTests/MerchantPreferancesTests.swift
+++ b/Tests/ModelTests/MerchantPreferancesTests.swift
@@ -38,9 +38,9 @@ final class MerchantPreferancesTests: XCTestCase {
         
         let generated = try String(data: encoder.encode(preferances), encoding: .utf8)!
         let json =
-            "{\"max_fail_attempts\":\"0\",\"char_set\":\"UTF-8\",\"initial_fail_amount_action\":\"CONTINUE\",\"cancel_url\":\"https:\\/\\/example.com\\/agreements\"," +
-            "\"return_url\":\"https:\\/\\/example.com\\/agreements\\/latest\",\"setup_fee\":{\"value\":\"0\",\"currency_code\":\"USD\"}," +
-            "\"auto_bill_amount\":\"YES\"}"
+            "{\"max_fail_attempts\":\"0\",\"char_set\":\"UTF-8\",\"initial_fail_amount_action\":\"CONTINUE\"," +
+            "\"cancel_url\":\"https:\\/\\/example.com\\/agreements\",\"return_url\":\"https:\\/\\/example.com\\/agreements\\/latest\"," +
+            "\"setup_fee\":{\"value\":\"0.00\",\"currency_code\":\"USD\"},\"auto_bill_amount\":\"YES\"}"
         
         // JSON is 434 characters long.
         var index = 0

--- a/Tests/ModelTests/MoneyRangeTests.swift
+++ b/Tests/ModelTests/MoneyRangeTests.swift
@@ -16,7 +16,8 @@ final class MoneyRangeTests: XCTestCase {
         let encoder = JSONEncoder()
         let range = MoneyRange(min: CurrencyCodeAmount(currency: .usd, value: 12.25), max: CurrencyCodeAmount(currency: .usd, value: 50.00))
         let generated = try String(data: encoder.encode(range), encoding: .utf8)
-        let json = "{\"minimum_amount\":{\"value\":\"12.25\",\"currency_code\":\"USD\"},\"maximum_amount\":{\"value\":\"50\",\"currency_code\":\"USD\"}}"
+        let json =
+            "{\"minimum_amount\":{\"value\":\"12.25\",\"currency_code\":\"USD\"},\"maximum_amount\":{\"value\":\"50.00\",\"currency_code\":\"USD\"}}"
         
         XCTAssertEqual(json, generated)
     }

--- a/Tests/ModelTests/MoneyTests.swift
+++ b/Tests/ModelTests/MoneyTests.swift
@@ -15,9 +15,13 @@ final class MoneyTests: XCTestCase {
         let xxx = try String(data: encoder.encode(CurrencyCodeAmount(currency: .xxx, value: 0)), encoding: .utf8)
         let eur = try String(data: encoder.encode(CurrencyCodeAmount(currency: .eur, value: 4.5)), encoding: .utf8)
         
+        let usdO = try String(data: encoder.encode(CurrencyCodeAmount(currency: .usd, value: 0)), encoding: .utf8)
+        
         XCTAssertEqual(usd, "{\"value\":\"12.25\",\"currency_code\":\"USD\"}")
         XCTAssertEqual(xxx, "{\"value\":\"0\",\"currency_code\":\"XXX\"}")
-        XCTAssertEqual(eur, "{\"value\":\"4.5\",\"currency_code\":\"EUR\"}")
+        XCTAssertEqual(eur, "{\"value\":\"4.50\",\"currency_code\":\"EUR\"}")
+        
+        XCTAssertEqual(usdO, "{\"value\":\"0.00\",\"currency_code\":\"USD\"}")
     }
     
     func testDecoding()throws {

--- a/Tests/ModelTests/OrderUnitTests.swift
+++ b/Tests/ModelTests/OrderUnitTests.swift
@@ -131,11 +131,12 @@ final class OrderUnitTests: XCTestCase {
         let generated = try String(data: encoder.encode(unit), encoding: .utf8)!
         let json =
             "{\"description\":\"Descript\",\"payment_summary\":{},\"payment_descriptor\":\"PayScript\"," +
-            "\"notify_url\":\"https:\\/\\/example.com\\/notify\",\"amount\":{\"total\":\"5\",\"currency\":\"USD\"}," +
+            "\"notify_url\":\"https:\\/\\/example.com\\/notify\",\"amount\":{\"currency\":\"USD\",\"total\":\"5.00\"}," +
             "\"invoice_number\":\"B5382984-3B90-4BC4-9F7A-6A6AFA61AC25\",\"metadata\":{\"supplementary_data\":[]},\"payee\":{}," +
             "\"reference_id\":\"C1C099F2-D7E7-4E19-BBBF-98DD11EA911A\",\"payment_linked_group\":1,\"shipping_address\":{\"country_code\":\"US\"," +
             "\"line1\":\"1 Infinate Loop\",\"city\":\"Cupertino\",\"postal_code\":\"94024\"},\"custom\":\"C2B9FBFB-B97D-46E4-8553-522C6A25A2FC\"," +
-            "\"items\":[],\"shipping_method\":\"USPSParcel\",\"partner_fee_details\":{\"amount\":{\"currency\":\"USD\",\"value\":\"2.5\"},\"receiver\":{}}}"
+            "\"items\":[],\"shipping_method\":\"USPSParcel\",\"partner_fee_details\":{\"amount\":{\"currency\":\"USD\",\"value\":\"2.50\"}," +
+            "\"receiver\":{}}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/PaymentDetailTests.swift
+++ b/Tests/ModelTests/PaymentDetailTests.swift
@@ -18,7 +18,7 @@ final class PaymentDetailTests: XCTestCase {
         let detail = PaymentDetail(date: self.now, method: .cash, note: "Hello World", amount: CurrencyAmount(currency: .usd, value: 4.50))
         let generated = try String(data: encoder.encode(detail), encoding: .utf8)!
         let json =
-            "{\"amount\":{\"currency\":\"USD\",\"value\":\"4.5\"},\"method\":\"CASH\",\"note\":\"Hello World\",\"date\":\"\(self.now.iso8601)\"}"
+            "{\"amount\":{\"currency\":\"USD\",\"value\":\"4.50\"},\"method\":\"CASH\",\"note\":\"Hello World\",\"date\":\"\(self.now.iso8601)\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/PaymentExecutorTests.swift
+++ b/Tests/ModelTests/PaymentExecutorTests.swift
@@ -13,7 +13,7 @@ final class PaymentExecutorTests: XCTestCase {
         let encoder = JSONEncoder()
         let executor = Payment.Executor(payer: "payer", amounts: [DetailedAmount(currency: .usd, total: 10.00, details: nil)])
         let generated = try String(data: encoder.encode(executor), encoding: .utf8)!
-        let json = "{\"payer_id\":\"payer\",\"transactions\":[{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"}}]}"
+        let json = "{\"payer_id\":\"payer\",\"transactions\":[{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"}}]}"
         
         XCTAssertEqual(generated, json)
     }

--- a/Tests/ModelTests/PaymentRefundTests.swift
+++ b/Tests/ModelTests/PaymentRefundTests.swift
@@ -47,7 +47,7 @@ final class PaymentRefundTests: XCTestCase {
             invoice: .init("inv")
         )
         let generated = try String(data: encoder.encode(refund), encoding: .utf8)!
-        let json = "{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"},\"reason\":\"reas\",\"description\":\"desc\",\"invoice_number\":\"inv\"}"
+        let json = "{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"},\"reason\":\"reas\",\"description\":\"desc\",\"invoice_number\":\"inv\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/PaymentTransactionTests.swift
+++ b/Tests/ModelTests/PaymentTransactionTests.swift
@@ -82,7 +82,7 @@ final class PaymentTransactionTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(transaction), encoding: .utf8)!
         let json =
-            "{\"amount\":{\"total\":\"54.56\",\"currency\":\"USD\"},\"custom\":\"custom\",\"item_list\":{}," +
+            "{\"amount\":{\"currency\":\"USD\",\"total\":\"54.56\"},\"custom\":\"custom\",\"item_list\":{}," +
             "\"notify_url\":\"https:\\/\\/example.com\\/notify\",\"payment_options\":{\"allowed_payment_method\":\"UNRESTRICTED\"}," +
             "\"soft_descriptor\":\"22\",\"description\":\"Description\",\"invoice_number\":\"12-654-89\",\"payee\":{},\"note_to_payee\":\"noted\"}"
         

--- a/Tests/ModelTests/RefundDetailTests.swift
+++ b/Tests/ModelTests/RefundDetailTests.swift
@@ -18,7 +18,7 @@ final class RefundDetailTests: XCTestCase {
         let encoder = JSONEncoder()
         let detail = RefundDetail(date: self.now, note: "Hello World", amount: CurrencyAmount(currency: .usd, value: 4.50))
         let generated = try String(data: encoder.encode(detail), encoding: .utf8)!
-        let json = "{\"date\":\"\(self.now.iso8601)\",\"amount\":{\"currency\":\"USD\",\"value\":\"4.5\"},\"note\":\"Hello World\"}"
+        let json = "{\"date\":\"\(self.now.iso8601)\",\"amount\":{\"currency\":\"USD\",\"value\":\"4.50\"},\"note\":\"Hello World\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/RefundTests.swift
+++ b/Tests/ModelTests/RefundTests.swift
@@ -12,7 +12,7 @@ final class RefundTests: XCTestCase {
         let encoder = JSONEncoder()
         let refund = Refund(amount: DetailedAmount(currency: .usd, total: 10.00, details: nil))
         let generated = try String(data: encoder.encode(refund), encoding: .utf8)!
-        let json = "{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"}}"
+        let json = "{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/RelatedResourceAuthorizationTests.swift
+++ b/Tests/ModelTests/RelatedResourceAuthorizationTests.swift
@@ -38,7 +38,11 @@ final class RelatedResourceAuthorizationTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(auth), encoding: .utf8)!
         
-        let json = "{\"amount\":{\"total\":\"5896\",\"currency\":\"USD\"},\"fmf_details\":{\"filter_id\":\"BILLING_OR_SHIPPING_ADDRESS_MISMATCH\",\"name\":\"Name\",\"description\":\"Desc.\",\"filter_type\":\"DENY\"},\"processor_response\":{\"avs_code\":\"e\",\"response_code\":\"6399\",\"advice_code\":\"01_NEW_ACCOUNT_INFORMATION\",\"cvv_code\":\"h\",\"eci_submitted\":\"152823\",\"vpas\":\"stat\"}}"
+        let json =
+            "{\"amount\":{\"currency\":\"USD\",\"total\":\"5896.00\"},\"fmf_details\":{\"filter_id\":\"BILLING_OR_SHIPPING_ADDRESS_MISMATCH\"," +
+            "\"name\":\"Name\",\"description\":\"Desc.\",\"filter_type\":\"DENY\"},\"processor_response\":{\"avs_code\":\"e\"," +
+            "\"response_code\":\"6399\",\"advice_code\":\"01_NEW_ACCOUNT_INFORMATION\",\"cvv_code\":\"h\",\"eci_submitted\":\"152823\"," +
+            "\"vpas\":\"stat\"}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/RelatedResourceCaptureTests.swift
+++ b/Tests/ModelTests/RelatedResourceCaptureTests.swift
@@ -56,7 +56,9 @@ final class RelatedResourceCaptureTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(capture), encoding: .utf8)!
         
-        let json = "{\"amount\":{\"total\":\"67.23\",\"currency\":\"USD\"},\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"2.71\"},\"note_to_payer\":\"Notable text\",\"is_final_capture\":false,\"invoice_number\":\"242841E3-7ADE-4C5C-AC88-78103E2132F2\"}"
+        let json =
+            "{\"amount\":{\"currency\":\"USD\",\"total\":\"67.23\"},\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"2.71\"}," +
+            "\"note_to_payer\":\"Notable text\",\"is_final_capture\":false,\"invoice_number\":\"242841E3-7ADE-4C5C-AC88-78103E2132F2\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/RelatedResourceOrderTests.swift
+++ b/Tests/ModelTests/RelatedResourceOrderTests.swift
@@ -33,7 +33,9 @@ final class RelatedResourceOrderTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(order), encoding: .utf8)!
         
-        let json = "{\"amount\":{\"total\":\"645.12\",\"currency\":\"USD\"},\"fmf_details\":{\"filter_id\":\"MAXIMUM_TRANSACTION_AMOUNT\",\"filter_type\":\"ACCEPT\"}}"
+        let json =
+            "{\"amount\":{\"currency\":\"USD\",\"total\":\"645.12\"},\"fmf_details\":{\"filter_id\":\"MAXIMUM_TRANSACTION_AMOUNT\"," +
+            "\"filter_type\":\"ACCEPT\"}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/RelatedResourceRefundTests.swift
+++ b/Tests/ModelTests/RelatedResourceRefundTests.swift
@@ -51,7 +51,7 @@ final class RelatedResourceRefundTests: XCTestCase {
         let generated = try String(data: encoder.encode(refund), encoding: .utf8)!
         
         let json =
-            "{\"amount\":{\"total\":\"67.23\",\"currency\":\"USD\"},\"reason\":\"Reasonable\",\"description\":\"Descript\"," +
+            "{\"amount\":{\"currency\":\"USD\",\"total\":\"67.23\"},\"reason\":\"Reasonable\",\"description\":\"Descript\"," +
             "\"invoice_number\":\"3086FF5B-13F2-4B6A-AB02-AD1C347B163C\"}"
         
         var index = 0

--- a/Tests/ModelTests/RelatedResourceSaleTests.swift
+++ b/Tests/ModelTests/RelatedResourceSaleTests.swift
@@ -46,7 +46,7 @@ final class RelatedResourceSaleTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(sale), encoding: .utf8)!
         
-        let json = "{\"amount\":{\"total\":\"42.31\",\"currency\":\"USD\"},\"id\":\"9FF17892-49F8-47C9-8117-7662F889DAEA\",\"exchange_rate\":\"0.0\",\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"0.31\"},\"receivable_amount\":{\"currency\":\"USD\",\"value\":\"42\"},\"fmf_details\":{\"filter_id\":\"BILLING_OR_SHIPPING_ADDRESS_MISMATCH\",\"name\":\"Name\",\"description\":\"Desc.\",\"filter_type\":\"DENY\"},\"create_time\":\"\(self.now.iso8601)\",\"parent_payment\":\"E7FBF930-B0F3-4514-B1DD-810BDCD6541F\",\"state\":\"pending\",\"processor_response\":{\"avs_code\":\"e\",\"response_code\":\"6399\",\"advice_code\":\"01_NEW_ACCOUNT_INFORMATION\",\"cvv_code\":\"h\",\"eci_submitted\":\"152823\",\"vpas\":\"stat\"}}"
+        let json = "{\"amount\":{\"currency\":\"USD\",\"total\":\"42.31\"},\"id\":\"9FF17892-49F8-47C9-8117-7662F889DAEA\",\"exchange_rate\":\"0.0\",\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"0.31\"},\"receivable_amount\":{\"currency\":\"USD\",\"value\":\"42.00\"},\"fmf_details\":{\"filter_id\":\"BILLING_OR_SHIPPING_ADDRESS_MISMATCH\",\"name\":\"Name\",\"description\":\"Desc.\",\"filter_type\":\"DENY\"},\"create_time\":\"\(self.now.iso8601)\",\"parent_payment\":\"E7FBF930-B0F3-4514-B1DD-810BDCD6541F\",\"state\":\"pending\",\"processor_response\":{\"avs_code\":\"e\",\"response_code\":\"6399\",\"advice_code\":\"01_NEW_ACCOUNT_INFORMATION\",\"cvv_code\":\"h\",\"eci_submitted\":\"152823\",\"vpas\":\"stat\"}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/RelatedResourceTests.swift
+++ b/Tests/ModelTests/RelatedResourceTests.swift
@@ -34,9 +34,9 @@ final class RelatedResourceTests: XCTestCase {
         let generated = try String(data: encoder.encode(resource), encoding: .utf8)!
         
         let json =
-            "{\"refund\":{},\"order\":{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"}}," +
-            "\"sale\":{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"},\"id\":\"\",\"state\":\"pending\",\"create_time\":\"\(date.iso8601)\"," +
-            "\"parent_payment\":\"10\"},\"authorization\":{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"}},\"capture\":{}}"
+            "{\"refund\":{},\"order\":{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"}}," +
+            "\"sale\":{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"},\"id\":\"\",\"state\":\"pending\",\"create_time\":\"\(date.iso8601)\"," +
+            "\"parent_payment\":\"10\"},\"authorization\":{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"}},\"capture\":{}}"
         
         
         var index = 0

--- a/Tests/ModelTests/SaleTests.swift
+++ b/Tests/ModelTests/SaleTests.swift
@@ -18,7 +18,7 @@ final class SaleTests: XCTestCase {
         let encoder = JSONEncoder()
         let sale = Sale(amount: DetailedAmount(currency: .usd, total: 10.00, details: nil), transaction: CurrencyAmount(currency: .usd, value: 1.00))
         let generated = try String(data: encoder.encode(sale), encoding: .utf8)!
-        let json = "{\"amount\":{\"total\":\"10\",\"currency\":\"USD\"},\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"1\"}}"
+        let json = "{\"amount\":{\"currency\":\"USD\",\"total\":\"10.00\"},\"transaction_fee\":{\"currency\":\"USD\",\"value\":\"1.00\"}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/ShippingCostsTests.swift
+++ b/Tests/ModelTests/ShippingCostsTests.swift
@@ -20,8 +20,8 @@ final class ShippingCostsTests: XCTestCase {
         )
         let generated = try String(data: encoder.encode(shipping), encoding: .utf8)!
         let json =
-            "{\"amount\":{\"currency\":\"USD\",\"value\":\"2.5\"},\"tax\":{\"name\":\"Shipping\",\"percent\":7.5,\"amount\":{\"currency\":\"USD\"," +
-        "\"value\":\"0.18\"}}}"
+            "{\"amount\":{\"currency\":\"USD\",\"value\":\"2.50\"},\"tax\":{\"name\":\"Shipping\",\"percent\":7.5,\"amount\":{\"currency\":\"USD\"," +
+            "\"value\":\"0.18\"}}}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/TemplateDataTests.swift
+++ b/Tests/ModelTests/TemplateDataTests.swift
@@ -135,12 +135,13 @@ final class TemplateDataTests: XCTestCase {
         let json =
             "{\"tax_calculated_after_discount\":true,\"logo_url\":\"https:\\/\\/vapor.codes\\/dist\\/e032390c38279fbdf18ebf0e763eb44f.png\"," +
             "\"note\":\"Thanks for your donation!\",\"billing_info\":[],\"allow_partial_payment\":false," +
-            "\"minimum_amount_due\":{\"currency\":\"USD\",\"value\":\"1\"},\"merchant_info\":{\"email\":\"hello@vapor.codes\"" +
+            "\"minimum_amount_due\":{\"currency\":\"USD\",\"value\":\"1.00\"},\"merchant_info\":{\"email\":\"hello@vapor.codes\"" +
             ",\"last_name\":\"Nelson\",\"website\":\"https:\\/\\/vapor.codes\\/\",\"business_name\":\"Qutheory LLC.\",\"first_name\":\"Tanner\"}," +
             "\"cc_info\":[{\"email\":\"collective@vapor.codes\"},{\"email\":\"donator@example.com\"}],\"payment_term\":{" +
-            "\"due_date\":\"\(self.timlessNow)\",\"term_type\":\"DUE_ON_RECEIPT\"},\"custom\":{\"amount\":{\"currency\":\"USD\",\"value\":\"10\"}}," +
-            "\"attachments\":[{\"name\":\"photo.jpg\",\"url\":\"https:\\/\\/avatars3.githubusercontent.com\\/u\\/2872298?s=200&v=4\"}]," +
-            "\"reference\":\"PO number\",\"tax_inclusive\":true,\"merchant_memo\":\"Open Collective donation\"}"
+            "\"due_date\":\"\(self.timlessNow)\",\"term_type\":\"DUE_ON_RECEIPT\"}," +
+            "\"custom\":{\"amount\":{\"currency\":\"USD\",\"value\":\"10.00\"}},\"attachments\":[{\"name\":\"photo.jpg\"," +
+            "\"url\":\"https:\\/\\/avatars3.githubusercontent.com\\/u\\/2872298?s=200&v=4\"}],\"reference\":\"PO number\",\"tax_inclusive\":true," +
+            "\"merchant_memo\":\"Open Collective donation\"}"
         
         var index = 0
         for (jsonChar, genChar) in zip(json, generated) {

--- a/Tests/ModelTests/TransactionTests.swift
+++ b/Tests/ModelTests/TransactionTests.swift
@@ -32,7 +32,7 @@ final class TransactionTests: XCTestCase {
         let generated = try String(data: encoder.encode(transaction), encoding: .utf8)
         let json =
             "{\"amount\":{\"value\":\"79.25\",\"currency_code\":\"USD\"},\"fee_amount\":{\"value\":\"7.25\",\"currency_code\":\"USD\"}," +
-            "\"net_amount\":{\"value\":\"72\",\"currency_code\":\"USD\"}}"
+            "\"net_amount\":{\"value\":\"72.00\",\"currency_code\":\"USD\"}}"
         
         XCTAssertEqual(generated, json)
     }


### PR DESCRIPTION
Format money decimal values with trailing 0 characters, so there are as many fraction digits as the currency exponent number:

```
85.8 USD => 85.80
10 USD => 10.00
10 XXX => 10
```

While most PayPal endpoints don't require this padding, some do, so we just do it for all models because it is easier that way and shouldn't break anything.